### PR TITLE
Refactor subgraph providers:

### DIFF
--- a/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/ItineraryIdeasProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/ItineraryIdeasProvider.kt
@@ -1,18 +1,9 @@
 package org.jetbrains.demo.agent.chat.strategy
 
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import ai.koog.agents.ext.agent.ProvideSubgraphResult
 import ai.koog.agents.ext.agent.SubgraphResult
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import org.jetbrains.demo.PointOfInterest
-
-@Serializable
-data class Test(val example: String) {
-}
 
 @Serializable
 data class ItineraryIdeas(val pointsOfInterest: List<PointOfInterest>) : SubgraphResult {
@@ -20,54 +11,10 @@ data class ItineraryIdeas(val pointsOfInterest: List<PointOfInterest>) : Subgrap
         Json.encodeToString(serializer(), this)
 }
 
-object ItineraryIdeasProvider : ProvideSubgraphResult<ItineraryIdeas>() {
-    override val argsSerializer = ItineraryIdeas.serializer()
-
-    override val descriptor = ToolDescriptor(
-        name = "provide_itinerary_ideas",
-        description = """
+val ItineraryIdeasProvider = SubgraphResultProvider<ItineraryIdeas>(
+    name = "provide_itinerary_ideas",
+    description = """
             Finish tool to compile final suggestion for the user's itinerary.
             Call to provide the final conclusion suggestion itinerary ideas result.
         """.trimIndent(),
-        requiredParameters = listOf(
-            ToolParameterDescriptor(
-                name = "pointsOfInterest",
-                description = "The points of interest in the suggested itinerary",
-                type = ToolParameterType.List(PointOfInterestType())
-            )
-        ),
-    )
-
-    override suspend fun execute(args: ItineraryIdeas): ItineraryIdeas = args
-}
-
-fun PointOfInterestType(): ToolParameterType.Object = ToolParameterType.Object(
-    properties = listOf(
-        ToolParameterDescriptor(
-            name = "name",
-            description = "The name of the point of interest",
-            type = ToolParameterType.String
-        ),
-        ToolParameterDescriptor(
-            name = "description",
-            description = "Description of the point of interest",
-            type = ToolParameterType.String
-        ),
-        ToolParameterDescriptor(
-            name = "location",
-            description = "The location of the point of interest",
-            type = ToolParameterType.String
-        ),
-        ToolParameterDescriptor(
-            name = "fromDate",
-            description = "Start date for visiting this point of interest in the ISO format, e.g. 2022-01-01",
-            type = ToolParameterType.String
-        ),
-        ToolParameterDescriptor(
-            name = "toDate",
-            description = "End date for visiting this point of interest in the ISO format, e.g. 2022-01-01",
-            type = ToolParameterType.String
-        )
-    ),
-    requiredProperties = listOf("name", "description", "location", "fromDate", "toDate")
 )

--- a/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/ProposedTravelPlanProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/ProposedTravelPlanProvider.kt
@@ -1,12 +1,7 @@
 package org.jetbrains.demo.agent.chat.strategy
 
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.ext.agent.ProvideSubgraphResult
 import ai.koog.agents.ext.agent.SubgraphResult
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.jetbrains.demo.Day
@@ -14,17 +9,17 @@ import org.jetbrains.demo.InternetResource
 
 @Serializable
 data class ProposedTravelPlan(
-    @LLMDescription("Catchy title appropriate to the travelers and input form")
+    @param:LLMDescription("Catchy title appropriate to the travelers and input form")
     val title: String,
-    @LLMDescription("Detailed travel plan in markdown format")
+    @param:LLMDescription("Detailed travel plan in markdown format")
     val plan: String,
-    @LLMDescription("List of days in the travel plan")
+    @param:LLMDescription("List of days in the travel plan")
     val days: List<Day>,
-    @LLMDescription("Links to images")
+    @param:LLMDescription("Links to images")
     val imageLinks: List<InternetResource>,
-    @LLMDescription("Links to pages with more information about the travel plan")
+    @param:LLMDescription("Links to pages with more information about the travel plan")
     val pageLinks: List<InternetResource>,
-    @LLMDescription("List of country names that the travelers will visit")
+    @param:LLMDescription("List of country names that the travelers will visit")
     val countriesVisited: List<String>,
 ) : SubgraphResult {
     override fun toStringDefault(): String =
@@ -34,63 +29,10 @@ data class ProposedTravelPlan(
         org.jetbrains.demo.ProposedTravelPlan(title, plan, days, imageLinks, pageLinks, countriesVisited)
 }
 
-object ProposedTravelPlanProvider : ProvideSubgraphResult<ProposedTravelPlan>() {
-    override val argsSerializer: KSerializer<ProposedTravelPlan> = ProposedTravelPlan.serializer()
-
-    override val descriptor: ToolDescriptor = ToolDescriptor(
-        name = "provide_proposed_travel_plan",
-        description = """
+val ProposedTravelPlanProvider = SubgraphResultProvider<ProposedTravelPlan>(
+    name = "provide_proposed_travel_plan",
+    description = """
             Finish tool to compile the proposal travel plan.
             Call to provide the proposal travel plan result.
-        """.trimIndent(),
-        requiredParameters = listOf(
-            ToolParameterDescriptor(
-                name = "title",
-                description = "Catchy title appropriate to the travelers and travel brief",
-                type = ToolParameterType.String
-            ),
-            ToolParameterDescriptor(
-                name = "plan",
-                description = "Detailed travel plan in markdown format",
-                type = ToolParameterType.String
-            ),
-            ToolParameterDescriptor(
-                name = "days",
-                description = "List of days in the travel plan",
-                type = ToolParameterType.List(
-                    ToolParameterType.Object(
-                        properties = listOf(
-                            ToolParameterDescriptor(
-                                name = "date",
-                                description = "Date in the format YYYY-MM-DD",
-                                type = ToolParameterType.String
-                            ),
-                            ToolParameterDescriptor(
-                                name = "locationAndCountry",
-                                description = "Location where the traveler will stay on this day in Google Maps friendly format 'City,+Country'",
-                                type = ToolParameterType.String
-                            )
-                        )
-                    )
-                )
-            ),
-            ToolParameterDescriptor(
-                name = "imageLinks",
-                description = "Links to image resources about the travel plan",
-                type = ToolParameterType.List(InternetResource())
-            ),
-            ToolParameterDescriptor(
-                name = "pageLinks",
-                description = "Links to internet resources about the travel plan",
-                type = ToolParameterType.List(InternetResource())
-            ),
-            ToolParameterDescriptor(
-                name = "countriesVisited",
-                description = "List of country names that the travelers will visit",
-                type = ToolParameterType.List(ToolParameterType.String)
-            ),
-        ),
-    )
-
-    override suspend fun execute(args: ProposedTravelPlan): ProposedTravelPlan = args
-}
+        """.trimIndent()
+)

--- a/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/ResearchedPointsOfInterestProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/ResearchedPointsOfInterestProvider.kt
@@ -1,10 +1,6 @@
 package org.jetbrains.demo.agent.chat.strategy
 
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.ext.agent.ProvideSubgraphResult
 import ai.koog.agents.ext.agent.SubgraphResult
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -16,7 +12,7 @@ data class ResearchedPointOfInterest(
     val pointOfInterest: PointOfInterest,
     val research: String,
     val links: List<InternetResource>,
-    @LLMDescription("Links to images. Links must be the images themselves, not just links to them.")
+    @property:LLMDescription("Links to images. Links must be the images themselves, not just links to them.")
     val imageLinks: List<InternetResource>
 ) : SubgraphResult {
     override fun toStringDefault(): String =
@@ -26,54 +22,10 @@ data class ResearchedPointOfInterest(
         org.jetbrains.demo.ResearchedPointOfInterest(pointOfInterest, research, links, imageLinks)
 }
 
-object ResearchedPointOfInterestProvider : ProvideSubgraphResult<ResearchedPointOfInterest>() {
-    override val argsSerializer = ResearchedPointOfInterest.serializer()
-
-    override val descriptor = ToolDescriptor(
-        name = "provide_research_results",
-        description = """
+val ResearchedPointOfInterestProvider = SubgraphResultProvider<ResearchedPointOfInterest>(
+    name = "provide_research_results",
+    description = """
             Finish tool to compile final conclusion result of the research done on the points of interest.
             Call to provide the final research conclusion result.
         """.trimIndent(),
-        requiredParameters = listOf(
-            ToolParameterDescriptor(
-                name = "pointOfInterest",
-                description = "The points of interest in the suggested itinerary",
-                type = PointOfInterestType()
-            ),
-            ToolParameterDescriptor(
-                name = "research",
-                description = "Research information about the point of interest",
-                type = ToolParameterType.String
-            ),
-            ToolParameterDescriptor(
-                name = "links",
-                description = "Links to internet resources about the point of interest",
-                type = ToolParameterType.List(InternetResource())
-            ),
-            ToolParameterDescriptor(
-                name = "imageLinks",
-                description = "Links to image resources about the point of interest",
-                type = ToolParameterType.List(InternetResource())
-            )
-        ),
-    )
-
-    override suspend fun execute(args: ResearchedPointOfInterest): ResearchedPointOfInterest = args
-}
-
-fun InternetResource(): ToolParameterType.Object = ToolParameterType.Object(
-    properties = listOf(
-        ToolParameterDescriptor(
-            name = "url",
-            description = "URL of the internet resource",
-            type = ToolParameterType.String
-        ),
-        ToolParameterDescriptor(
-            name = "summary",
-            description = "Summary of the internet resource",
-            type = ToolParameterType.String
-        )
-    )
 )
-

--- a/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/SubgraphResultProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/demo/agent/chat/strategy/SubgraphResultProvider.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.demo.agent.chat.strategy
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.ext.agent.ProvideSubgraphResult
+import ai.koog.agents.ext.agent.SubgraphResult
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+import org.jetbrains.demo.agent.koog.tools.toolDescription
+
+@Suppress("FunctionName")
+inline fun <reified A : SubgraphResult> SubgraphResultProvider(
+    name: String,
+    description: String
+): ProvideSubgraphResult<A> =
+    object : ProvideSubgraphResult<A>() {
+        override val argsSerializer: KSerializer<A> = serializer<A>()
+        override val descriptor: ToolDescriptor = argsSerializer.descriptor.toolDescription(
+            name = name,
+            description = description,
+        )
+
+        override suspend fun execute(args: A): A = args
+    }

--- a/server/src/main/kotlin/org/jetbrains/demo/agent/koog/tools/ToolDescriptor.kt
+++ b/server/src/main/kotlin/org/jetbrains/demo/agent/koog/tools/ToolDescriptor.kt
@@ -1,0 +1,129 @@
+package org.jetbrains.demo.agent.koog.tools
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+
+/**
+ * Convert a [SerialDescriptor] to a [ToolDescriptor].
+ */
+public fun SerialDescriptor.toolDescription(
+    name: String,
+    description: String? = null
+): ToolDescriptor {
+    val description = description ?: annotations.filterIsInstance<LLMDescription>().firstOrNull()?.description ?: ""
+
+    return when (kind) {
+        PrimitiveKind.STRING -> ToolParameterType.String.asValueTool(name, description)
+        PrimitiveKind.BOOLEAN -> ToolParameterType.Boolean.asValueTool(name, description)
+        PrimitiveKind.CHAR -> ToolParameterType.String.asValueTool(name, description)
+        PrimitiveKind.BYTE,
+        PrimitiveKind.SHORT,
+        PrimitiveKind.INT,
+        PrimitiveKind.LONG -> ToolParameterType.Integer.asValueTool(name, description)
+
+        PrimitiveKind.FLOAT,
+        PrimitiveKind.DOUBLE -> ToolParameterType.Float.asValueTool(name, description)
+
+        StructureKind.LIST -> ToolParameterType.List(
+            getElementDescriptor(0).toToolParameterType()
+        ).asValueTool(name, description)
+
+        SerialKind.ENUM -> ToolParameterType.Enum(Array(elementsCount, ::getElementName))
+            .asValueTool(name, description)
+
+        StructureKind.CLASS -> {
+            val required = mutableListOf<String>()
+            val properties = List(elementsCount) { i ->
+                val name = getElementName(i)
+                if (!isElementOptional(i)) {
+                    required.add(name)
+                }
+                ToolParameterDescriptor(
+                    name,
+                    annotations.filterIsInstance<LLMDescription>().firstOrNull()?.description ?: "",
+                    getElementDescriptor(i).toToolParameterType()
+                )
+            }
+            ToolDescriptor(
+                name,
+                description,
+                requiredParameters = properties.filter { required.contains(it.name) },
+                optionalParameters = properties.filterNot { required.contains(it.name) }
+            )
+        }
+
+        // support FreeForm Object ToolDescriptor
+        PolymorphicKind.SEALED,
+        StructureKind.OBJECT,
+        SerialKind.CONTEXTUAL,
+        PolymorphicKind.OPEN,
+        StructureKind.MAP -> ToolDescriptor(
+            name = name,
+            description = description ?: "",
+            requiredParameters = emptyList(),
+            optionalParameters = emptyList()
+        )
+    }
+}
+
+private fun SerialDescriptor.toToolParameterType(): ToolParameterType = when (kind) {
+    PrimitiveKind.CHAR,
+    PrimitiveKind.STRING -> ToolParameterType.String
+
+    PrimitiveKind.BOOLEAN -> ToolParameterType.Boolean
+    PrimitiveKind.BYTE,
+    PrimitiveKind.SHORT,
+    PrimitiveKind.INT,
+    PrimitiveKind.LONG -> ToolParameterType.Integer
+
+    PrimitiveKind.FLOAT,
+    PrimitiveKind.DOUBLE -> ToolParameterType.Float
+
+    StructureKind.LIST -> ToolParameterType.List(getElementDescriptor(0).toToolParameterType())
+
+    SerialKind.ENUM -> ToolParameterType.Enum(Array(elementsCount, ::getElementName))
+
+    StructureKind.CLASS -> {
+        val required = mutableListOf<String>()
+        ToolParameterType.Object(
+            List(elementsCount) { i ->
+                val name = getElementName(i)
+                if (!isElementOptional(i)) {
+                    required.add(name)
+                }
+                ToolParameterDescriptor(
+                    name,
+                    annotations.filterIsInstance<LLMDescription>().firstOrNull()?.description ?: "",
+                    getElementDescriptor(i).toToolParameterType()
+                )
+            },
+            required,
+            false
+        )
+    }
+
+    PolymorphicKind.SEALED,
+    StructureKind.OBJECT,
+    SerialKind.CONTEXTUAL,
+    PolymorphicKind.OPEN,
+    StructureKind.MAP -> ToolParameterType.Object(
+        emptyList(),
+        emptyList(),
+        true,
+        ToolParameterType.String
+
+    )
+}
+
+private fun ToolParameterType.asValueTool(name: String, description: String) = ToolDescriptor(
+    name = name,
+    description = description,
+    requiredParameters = listOf(ToolParameterDescriptor(name = "value", description = "", this))
+)


### PR DESCRIPTION
- Introduce `SubgraphResultProvider` utility to simplify tool provider creation.
- Optimize `ToolDescriptor` generation with a reusable `toolDescription` extension.
- Add support for inline descriptor generation based on `SerialDescriptor`.